### PR TITLE
Tegra_stats Script

### DIFF
--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -4,6 +4,8 @@
 Script for monitoring the values of tegra_stats and logging them for viewing later 
 The output from tegrastats is synchronous (~ every 1s), so the absolute timestamps are not taken. 
 Instead, any plots assume contingous samples, meaning the index can be used for graphing"
+
+To use this script, you will need to have a smart_asphalt/log directory, the script will place a raw data file in it
 """
 
 import pandas as pd

--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -7,8 +7,8 @@ Instead, any plots assume contingous samples, meaning the index can be used for 
 """
 
 import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import os
 import time
 import re
@@ -45,6 +45,7 @@ class tegra_stats:
 		#create dataframe
 		df = pd.DataFrame(columns = ["inst_mw", "avg_mw"])
 		while line:
+			#match regex 
 			mtc = tegra_stats.reg.search(line)
 			if(mtc):
 				raw_match = mtc.group(0)
@@ -58,12 +59,21 @@ class tegra_stats:
 		#return dataframe
 		return df
 
+	@staticmethod
+	def plotGraph(df): 
+		plt.plot(df["inst_mw"])
+		plt.title("Power Consumption Over Time")
+		plt.xlabel("Time (Seconds relative to start of script)")		
+		plt.ylabel("Power (mw)")
+		plt.savefig("oof.png")
+
 def main():
 	proc = tegra_stats.get_tegra_stats()
-	time.sleep(5)
+	time.sleep(60)
 	tegra_stats.kill_tegra_stats(proc)
 	nice = tegra_stats.read_file()
 	print(nice.head())
+	tegra_stats.plotGraph(nice)
 
 if __name__ == "__main__":
 	main()

--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -11,10 +11,12 @@ import os
 import sys
 import timing
 import threading
+import subprocess
 
 class tegra_stats:
 
 	orig_stdout = sys.stdout
+	timeout 
 
 	@staticmethod
 	def init_stdout_to_file():
@@ -23,19 +25,29 @@ class tegra_stats:
 	#read all tegra stats
 	@staticmethod
 	def get_tegra_stats():
-		os.system("/usr/bin/tegrastats --logfile ~/smart_asphalt/logs/rawstats.txt")
+		t_stats = subprocess.Popen(["exec " + "/usr/bin/tegrastats --logfile ~/smart_asphalt/logs/rawstats.txt"], shell=True)
+		return t_stats
 
-	#writes control C to command line
+	#kill process
 	@staticmethod
-	def kill_tegra_stats():
-		os.system("\x03")
+	def kill_tegra_stats(t_stats):
+		t_stats.kill()
+
+	@staticmethod
+	def read_file():
+		#open text file
+		f = open("../logs/rawstats.txt", 'r')
+		lines = f.readlines()
+		#create dataframe
+		for l in lines:
+			#regex command 
+
+		#return dataframe
+
+def main():
+	proc = tegra_stats.get_tegra_stats()
+	timing.sleep_for(5)
+	tegra_stats.kill_tegra_stats(proc)
 
 if __name__ == "__main__":
-	collect = threading.Thread(target = tegra_stats.get_tegra_stats())
-	collect.daemon = True
-	collect.start()
-	collect.join()
-	tegra_stats.kill_tegra_stats()
-
-	while(1):
-		timing.sleep_for(1)
+	main()

--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -9,6 +9,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import os
 import sys
+import timing
+import threading
 
 class tegra_stats:
 
@@ -23,4 +25,17 @@ class tegra_stats:
 	def get_tegra_stats():
 		os.system("/usr/bin/tegrastats --logfile ~/smart_asphalt/logs/rawstats.txt")
 
-tegra_stats.get_tegra_stats()
+	#writes control C to command line
+	@staticmethod
+	def kill_tegra_stats():
+		os.system("\x03")
+
+if __name__ == "__main__":
+	collect = threading.Thread(target = tegra_stats.get_tegra_stats())
+	collect.daemon = True
+	collect.start()
+	collect.join()
+	tegra_stats.kill_tegra_stats()
+
+	while(1):
+		timing.sleep_for(1)

--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -2,21 +2,24 @@
 
 """ 
 Script for monitoring the values of a script and logging them for viewing later 
+The output from tegrastats is synchronous (~ every 1s), so the absolute timestamps are not taken. 
+Instead, any plots assume contingous samples, meaning the index can be used for graphing"
 """
 
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import os
+import time
+import re
 import sys
-import timing
-import threading
 import subprocess
 
 class tegra_stats:
 
+	reg = re.compile("POM_5V_IN \d+\/\d+")
 	orig_stdout = sys.stdout
-	timeout 
+	timeout = 0 
 
 	@staticmethod
 	def init_stdout_to_file():
@@ -37,17 +40,30 @@ class tegra_stats:
 	def read_file():
 		#open text file
 		f = open("../logs/rawstats.txt", 'r')
-		lines = f.readlines()
+		line = str(f.readline())
+		count = 0
 		#create dataframe
-		for l in lines:
-			#regex command 
+		df = pd.DataFrame(columns = ["inst_mw", "avg_mw"])
+		while line:
+			mtc = tegra_stats.reg.search(line)
+			if(mtc):
+				raw_match = mtc.group(0)
+				nums = raw_match.split()[1]
+				power = nums.split('/')
+				df.loc[count] = [power[0], power[1]]
+			#else, raise exception
+			line = str(f.readline())
+			count += 1
 
 		#return dataframe
+		return df
 
 def main():
 	proc = tegra_stats.get_tegra_stats()
-	timing.sleep_for(5)
+	time.sleep(5)
 	tegra_stats.kill_tegra_stats(proc)
+	nice = tegra_stats.read_file()
+	print(nice.head())
 
 if __name__ == "__main__":
 	main()

--- a/src/tegra_stats.py
+++ b/src/tegra_stats.py
@@ -1,0 +1,26 @@
+#!/user/bin/python3 
+
+""" 
+Script for monitoring the values of a script and logging them for viewing later 
+"""
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+import sys
+
+class tegra_stats:
+
+	orig_stdout = sys.stdout
+
+	@staticmethod
+	def init_stdout_to_file():
+		sys.stdout = open("tegra_log.csv", 'w')
+
+	#read all tegra stats
+	@staticmethod
+	def get_tegra_stats():
+		os.system("/usr/bin/tegrastats --logfile ~/smart_asphalt/logs/rawstats.txt")
+
+tegra_stats.get_tegra_stats()


### PR DESCRIPTION
Script for measuring the power consumption of the Jetson Nano over the runtime of the script and then saving it to a PNG. Person running the script will need a smart_asphalt/log directory, in which the data file will be written. 